### PR TITLE
Limit endorse button to instructors

### DIFF
--- a/public/openapi/read/topic/topic_id.yaml
+++ b/public/openapi/read/topic/topic_id.yaml
@@ -321,6 +321,8 @@ get:
                         type: boolean
                       posts:delete:
                         type: boolean
+                      posts:endorse:
+                        type: boolean
                       posts:view_deleted:
                         type: boolean
                       read:

--- a/src/api/posts.js
+++ b/src/api/posts.js
@@ -274,10 +274,19 @@ postsAPI.unbookmark = async function (caller, data) {
 };
 
 postsAPI.endorse = async function (caller, data) {
+    const userPrivileges = await privileges.posts.get([data.pid], caller.uid);
+    if (!userPrivileges[0]["isAdminOrMod"]) {
+        throw new Error('[[error:no-privileges]]');
+    }
+    
     return await apiHelpers.postCommand(caller, 'endorse', 'endorsed', '', data);
 };
 
 postsAPI.unendorse = async function (caller, data) {
+    const userPrivileges = await privileges.posts.get([data.pid], caller.uid);
+    if (!userPrivileges[0]["isAdminOrMod"]) {
+        throw new Error('[[error:no-privileges]]');
+    }
     return await apiHelpers.postCommand(caller, 'unendorse', 'endorsed', '', data);
 };
 

--- a/src/api/posts.js
+++ b/src/api/posts.js
@@ -275,16 +275,16 @@ postsAPI.unbookmark = async function (caller, data) {
 
 postsAPI.endorse = async function (caller, data) {
     const userPrivileges = await privileges.posts.get([data.pid], caller.uid);
-    if (!userPrivileges[0]["isAdminOrMod"]) {
+    if (!userPrivileges[0].isAdminOrMod) {
         throw new Error('[[error:no-privileges]]');
     }
-    
+
     return await apiHelpers.postCommand(caller, 'endorse', 'endorsed', '', data);
 };
 
 postsAPI.unendorse = async function (caller, data) {
     const userPrivileges = await privileges.posts.get([data.pid], caller.uid);
-    if (!userPrivileges[0]["isAdminOrMod"]) {
+    if (!userPrivileges[0].isAdminOrMod) {
         throw new Error('[[error:no-privileges]]');
     }
     return await apiHelpers.postCommand(caller, 'unendorse', 'endorsed', '', data);

--- a/src/posts/endorse.js
+++ b/src/posts/endorse.js
@@ -58,13 +58,12 @@ function default_1(Posts) {
             if (Array.isArray(pid)) {
                 const sets = pid.map(pid => `pid:${pid}:users_endorsed`);
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-                const counts = yield db.setsCount(sets);
-                return counts.map(function (v) {
-                    return v > 0;
-                });
+                const counts = yield db.setsCount(sets); // eslint-disable-line @typescript-eslint/no-unsafe-assignment
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
+                return counts.map(v => v > 0); // eslint-disable-line @typescript-eslint/no-unsafe-member-access
             }
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-            const count = yield db.setCount(`pid:${pid}:users_endorsed`);
+            const count = yield db.setCount(`pid:${pid}:users_endorsed`); // eslint-disable-line @typescript-eslint/no-unsafe-assignment
             return count > 0;
         });
     };

--- a/src/posts/endorse.js
+++ b/src/posts/endorse.js
@@ -58,10 +58,10 @@ function default_1(Posts) {
             if (Array.isArray(pid)) {
                 const sets = pid.map(pid => `pid:${pid}:users_endorsed`);
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-                return yield db.isMemberOfSets(sets, uid);
+                return yield db.setsCount(sets);
             }
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-            return yield db.isSetMember(`pid:${pid}:users_endorsed`, uid);
+            return yield db.setCount(`pid:${pid}:users_endorsed`);
         });
     };
     Posts.endorse = function (pid, uid) {

--- a/src/posts/endorse.js
+++ b/src/posts/endorse.js
@@ -58,10 +58,14 @@ function default_1(Posts) {
             if (Array.isArray(pid)) {
                 const sets = pid.map(pid => `pid:${pid}:users_endorsed`);
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-                return yield db.setsCount(sets);
+                const counts = yield db.setsCount(sets);
+                return counts.map(function (v) {
+                    return v > 0;
+                });
             }
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-            return yield db.setCount(`pid:${pid}:users_endorsed`);
+            const count = yield db.setCount(`pid:${pid}:users_endorsed`);
+            return count > 0;
         });
     };
     Posts.endorse = function (pid, uid) {

--- a/src/posts/endorse.ts
+++ b/src/posts/endorse.ts
@@ -70,13 +70,12 @@ export default function (Posts: PostsType) {
         if (Array.isArray(pid)) {
             const sets = pid.map(pid => `pid:${pid}:users_endorsed`);
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-            const counts = await db.setsCount(sets)
-            return counts.map(function(v) {
-                return v > 0;
-              });
+            const counts = await db.setsCount(sets); // eslint-disable-line @typescript-eslint/no-unsafe-assignment
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
+            return counts.map(v => v > 0); // eslint-disable-line @typescript-eslint/no-unsafe-member-access
         }
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        const count = await db.setCount(`pid:${pid}:users_endorsed`)
+        const count = await db.setCount(`pid:${pid}:users_endorsed`); // eslint-disable-line @typescript-eslint/no-unsafe-assignment
         return count > 0;
     };
 

--- a/src/posts/endorse.ts
+++ b/src/posts/endorse.ts
@@ -70,10 +70,10 @@ export default function (Posts: PostsType) {
         if (Array.isArray(pid)) {
             const sets = pid.map(pid => `pid:${pid}:users_endorsed`);
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-            return await db.isMemberOfSets(sets, uid) as boolean[];
+            return await db.setsCount(sets) as boolean[];
         }
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        return await db.isSetMember(`pid:${pid}:users_endorsed`, uid) as boolean;
+        return await db.setCount(`pid:${pid}:users_endorsed`) as boolean;
     };
 
     Posts.endorse = async function (pid: string, uid: string) {

--- a/src/posts/endorse.ts
+++ b/src/posts/endorse.ts
@@ -70,10 +70,14 @@ export default function (Posts: PostsType) {
         if (Array.isArray(pid)) {
             const sets = pid.map(pid => `pid:${pid}:users_endorsed`);
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-            return await db.setsCount(sets) as boolean[];
+            const counts = await db.setsCount(sets)
+            return counts.map(function(v) {
+                return v > 0;
+              });
         }
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        return await db.setCount(`pid:${pid}:users_endorsed`) as boolean;
+        const count = await db.setCount(`pid:${pid}:users_endorsed`)
+        return count > 0;
     };
 
     Posts.endorse = async function (pid: string, uid: string) {

--- a/src/privileges/topics.js
+++ b/src/privileges/topics.js
@@ -43,6 +43,7 @@ privsTopics.get = async function (tid, uid) {
         'topics:delete': (privData['topics:delete'] && (isOwner || isModerator)) || isAdministrator,
         'posts:edit': (privData['posts:edit'] && (!topicData.locked || isModerator)) || isAdministrator,
         'posts:history': privData['posts:history'] || isAdministrator,
+        'posts:endorse': privData['posts:endorse'] || isAdminOrMod,
         'posts:delete': (privData['posts:delete'] && (!topicData.locked || isModerator)) || isAdministrator,
         'posts:view_deleted': privData['posts:view_deleted'] || isAdministrator,
         read: privData.read || isAdministrator,

--- a/test/posts.js
+++ b/test/posts.js
@@ -318,8 +318,12 @@ describe('Post\'s', () => {
         });
 
         it('should fail if user does not have admin or mod privilege', async () => {
-            const data = await apiPosts.unendorse({ uid: voterUid }, { pid: postData.pid, room_id: `topic_${postData.tid}` });
-            assert.equal(err.message, '[[error:no-privileges]]');
+            try {
+                await apiPosts.unendorse({ uid: voterUid }, { pid: postData.pid, room_id: `topic_${postData.tid}` });
+            } catch (err) {
+                return assert.equal(err.message, '[[error:no-privileges]]');
+            }
+            assert(false);
         });
     });
 

--- a/test/posts.js
+++ b/test/posts.js
@@ -304,17 +304,22 @@ describe('Post\'s', () => {
 
     describe('endorsing', () => {
         it('should endorse a post', async () => {
-            const data = await apiPosts.endorse({ uid: voterUid }, { pid: postData.pid, room_id: `topic_${postData.tid}` });
+            const data = await apiPosts.endorse({ uid: globalModUid }, { pid: postData.pid, room_id: `topic_${postData.tid}` });
             assert.equal(data.isEndorsed, true);
             const hasEndorsed = await posts.hasEndorsed(postData.pid, voterUid);
             assert.equal(hasEndorsed, true);
         });
 
         it('should unendorse a post', async () => {
-            const data = await apiPosts.unendorse({ uid: voterUid }, { pid: postData.pid, room_id: `topic_${postData.tid}` });
+            const data = await apiPosts.unendorse({ uid: globalModUid }, { pid: postData.pid, room_id: `topic_${postData.tid}` });
             assert.equal(data.isEndorsed, false);
             const hasEndorsed = await posts.hasEndorsed([postData.pid], voterUid);
             assert.equal(hasEndorsed[0], false);
+        });
+
+        it('should fail if user does not have admin or mod privilege', async () => {
+            const data = await apiPosts.unendorse({ uid: voterUid }, { pid: postData.pid, room_id: `topic_${postData.tid}` });
+            assert.equal(err.message, '[[error:no-privileges]]');
         });
     });
 

--- a/themes/nodebb-theme-persona/less/topic.less
+++ b/themes/nodebb-theme-persona/less/topic.less
@@ -601,10 +601,7 @@
 }
 
 .endorse-msg {
-
-	p {
-		text-align: center;
-	}
+	text-align: center;
 	color: #e8a74d;
 }
 

--- a/themes/nodebb-theme-persona/templates/partials/topic/endorse-msg.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/endorse-msg.tpl
@@ -1,7 +1,7 @@
-<div class="endorse-msg">
-<!-- IF posts.endorsed -->
-<p >An instructor has endorsed this post!</p>
-<!-- ELSE -->
-<p hidden>An instructor has endorsed this post!</p>
-<!-- ENDIF posts.endorsed -->
+<div class="endorse-msg"
+<!-- IF !posts.endorsed -->
+hidden
+<!-- ENDIF !posts.endorsed -->
+>
+An instructor has endorsed this post!
 </div>

--- a/themes/nodebb-theme-persona/templates/partials/topic/endorse-toggle.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/endorse-toggle.tpl
@@ -1,3 +1,5 @@
+<!-- IF privileges.posts:endorse -->
 <a component="post/endorse" data-endorsed="{posts.endorsed}" href="#" class="no-select">
 <!-- IF !posts.endorsed -->Endorse<!-- ELSE -->Unendorse<!-- ENDIF !posts.endorsed -->
 </a>
+<!-- ENDIF privileges.posts:endorse -->

--- a/themes/nodebb-theme-persona/templates/partials/topics_list.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topics_list.tpl
@@ -75,6 +75,10 @@
             <span class="human-readable-number">{topics.postcount}</span> <a href="{config.relative_path}/topic/{topics.slug}/{topics.teaser.index}"><i class="fa fa-arrow-circle-right"></i></a>
         </div>
 
+        <!-- IF !topics.teaser.endorsed -->
+        <div>hi</div>
+        <!-- ENDIF !topics.teaser.endorsed -->
+
         <div class="col-md-1 hidden-sm hidden-xs stats stats-votes">
             <!-- IF !reputation:disabled -->
             <span class="human-readable-number" title="{topics.votes}">{topics.votes}</span><br />


### PR DESCRIPTION
Resolves #30 and #32 
### Changes Made:
- Added test cases to test previous PR #31 
- Added endorse button for moderators and admins only - mocking instructor role since not implemented yet

### Testing Changes:
I did manual tests on the build:
No endorse button for nonadmin
<img width="1278" alt="Screen Shot 2023-10-10 at 11 41 10 PM" src="https://github.com/CMU-313/fall23-nodebb-qwerty-coders/assets/84979255/4323b3bf-beed-454b-b334-0d7923dc3f26">
Endorse button for admin
<img width="1269" alt="Screen Shot 2023-10-10 at 11 41 20 PM" src="https://github.com/CMU-313/fall23-nodebb-qwerty-coders/assets/84979255/a8fcec51-2376-415f-a2b1-e3405a41ee38">
I also added a test case to make sure that the nonAdmin account will error due to no privileges.