### PR TITLE
Fix private topic field incorrectly shown after merge

### DIFF
--- a/src/topics/data.js
+++ b/src/topics/data.js
@@ -129,7 +129,7 @@ function modifyTopic(topic, fields) {
     }
 
     if (topic.hasOwnProperty('isPrivate')) {
-        topic.isPrivate = topic.isPrivate === 'true';
+        topic.isPrivate = topic.isPrivate === true;
     }
 
     if (fields.includes('teaserPid') || !fields.length) {


### PR DESCRIPTION
Problem:
`isPrivate` field of topic is always false even with the toggle switch turned on after merging previous changes into main

Changes made:
Changed `hasOwnProperty` conditional check of `isPrivate` in topic data

How changes have been tested:
Manual test in local server
passes test suite and linter