### PR TITLE
Redis schema for Instructors and TAs

### DIFF
--- a/src/database/redis/instructors.js
+++ b/src/database/redis/instructors.js
@@ -1,0 +1,37 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getPerson = exports.savePerson = void 0;
+// instructors.ts
+const redis_1 = __importDefault(require("../redis"));
+const savePerson = (person) => __awaiter(void 0, void 0, void 0, function* () {
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    yield redis_1.default.hmset(person.username, person.email);
+});
+exports.savePerson = savePerson;
+const getPerson = (role, username) => __awaiter(void 0, void 0, void 0, function* () {
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+    const data = yield redis_1.default.hget(role, username);
+    if (data) {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const person = { username, email: data };
+        return person;
+    }
+    return null;
+});
+exports.getPerson = getPerson;

--- a/src/database/redis/instructors.js
+++ b/src/database/redis/instructors.js
@@ -23,7 +23,6 @@ const savePerson = (person) => __awaiter(void 0, void 0, void 0, function* () {
 exports.savePerson = savePerson;
 const getPerson = (role, username) => __awaiter(void 0, void 0, void 0, function* () {
     // The next line calls a function in a module that has not been updated to TS yet
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
     const data = yield redis_1.default.hget(role, username);
     if (data) {

--- a/src/database/redis/instructors.ts
+++ b/src/database/redis/instructors.ts
@@ -1,0 +1,29 @@
+// instructors.ts
+import redisModule from './connection';
+
+export interface Person {
+  username: string;
+  email: string;
+}
+
+export interface Instructor extends Person {
+  role: 'instructor';
+}
+
+export interface TA extends Person {
+  role: 'ta';
+}
+
+export const savePerson = async (person: Person) => {
+  await redisModule.hmset(person.username, person.email);
+};
+
+export const getPerson = async (role: 'instructor' | 'ta', username: string): Promise<Person | null> => {
+  const data = await redisModule.hget(role, username);
+
+  if (data) {
+    return { username, email: data } as Person;
+  } else {
+    return null;
+  }
+};

--- a/src/database/redis/instructors.ts
+++ b/src/database/redis/instructors.ts
@@ -1,29 +1,35 @@
 // instructors.ts
-import redisModule from './connection';
+import redisModule from '../redis';
 
 export interface Person {
-  username: string;
-  email: string;
+    username: string;
+    email: string;
 }
 
 export interface Instructor extends Person {
-  role: 'instructor';
+    role: 'instructor';
 }
 
 export interface TA extends Person {
-  role: 'ta';
+    role: 'ta';
 }
 
 export const savePerson = async (person: Person) => {
-  await redisModule.hmset(person.username, person.email);
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    await redisModule.hmset(person.username, person.email);
 };
 
 export const getPerson = async (role: 'instructor' | 'ta', username: string): Promise<Person | null> => {
-  const data = await redisModule.hget(role, username);
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+    const data: string | null = await redisModule.hget(role, username);
 
-  if (data) {
-    return { username, email: data } as Person;
-  } else {
+    if (data) {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const person: Person = { username, email: data };
+        return person;
+    }
     return null;
-  }
 };


### PR DESCRIPTION
resolves issue #21 
### Changes Made
* New instructors.ts file created in src/database/redis/instructors.ts 
* The fields for Instructors and TAs created with username and email attributes

### Testing
* Passes `npm run lint` and `npm run test`
